### PR TITLE
fix: use vcs.useIgnoreFile in biome to respect .gitignore

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -68,14 +68,12 @@
       "tailwindDirectives": true
     }
   },
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
   "files": {
-    "includes": [
-      "**",
-      "!**/node_modules",
-      "!**/dist",
-      "!**/.wrangler",
-      "!**/src/routeTree.gen.ts",
-      "!**/.claude"
-    ]
+    "includes": ["**", "!**/src/routeTree.gen.ts"]
   }
 }


### PR DESCRIPTION
## Summary
- biome の `vcs` 設定を追加し、`.gitignore` を自動的に尊重するように変更
- `.direnv` 内の `/nix/store/` へのシンボリックリンクが原因で 700+ 件の偽lintエラーが発生していた問題を解決
- `files.includes` から手動の除外パターン (`node_modules`, `dist`, `.wrangler`, `.claude`) を削除し、`.gitignore` に委譲してシンプル化

## Test plan
- [x] `nr lint` がエラー・警告なしで通ることを確認