### PR TITLE
feat: タブバーを固定島として分離

### DIFF
--- a/src/components/profile-panel.tsx
+++ b/src/components/profile-panel.tsx
@@ -168,28 +168,6 @@ export function ProfilePanel() {
               {activeTab === "SKILLS" && <SkillsTab />}
               {activeTab === "LINKS" && <LinksTab />}
             </div>
-
-            {/* Tab bar */}
-            <div className="flex mt-4">
-              {TABS.map((tab, i) => (
-                <button
-                  key={tab}
-                  type="button"
-                  onClick={() => setActiveTab(tab)}
-                  className={`flex-1 h-tab-h lg:h-[2.5rem] text-sm lg:text-lg font-squada tracking-wider transition-colors ${i > 0 ? "-ml-2" : ""} ${
-                    activeTab === tab
-                      ? "bg-accent text-text-on-accent z-10"
-                      : "bg-bg-dark text-muted-light hover:text-text-sub"
-                  }`}
-                  style={{
-                    clipPath:
-                      "polygon(12px 0, 100% 0, calc(100% - 12px) 100%, 0 100%)",
-                  }}
-                >
-                  {tab}
-                </button>
-              ))}
-            </div>
           </div>
         </div>
 
@@ -208,6 +186,30 @@ export function ProfilePanel() {
             vectorEffect="non-scaling-stroke"
           />
         </svg>
+      </div>
+
+      {/* Fixed tab bar island */}
+      <div className="fixed bottom-4 left-0 right-0 z-50 flex justify-center px-4 lg:px-6">
+        <div className="w-full max-w-panel-max lg:max-w-xl border-2 border-muted-light bg-bg-button flex items-center p-2 gap-2">
+          {TABS.map((tab, i) => (
+            <button
+              key={tab}
+              type="button"
+              onClick={() => setActiveTab(tab)}
+              className={`flex-1 h-tab-h lg:h-[2.5rem] text-sm lg:text-lg font-squada tracking-wider transition-colors ${i > 0 ? "-ml-2" : ""} ${
+                activeTab === tab
+                  ? "bg-accent text-text-on-accent z-10"
+                  : "bg-bg-dark text-muted-light hover:text-text-sub"
+              }`}
+              style={{
+                clipPath:
+                  "polygon(12px 0, 100% 0, calc(100% - 12px) 100%, 0 100%)",
+              }}
+            >
+              {tab}
+            </button>
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/src/components/profile-panel.tsx
+++ b/src/components/profile-panel.tsx
@@ -163,7 +163,7 @@ export function ProfilePanel() {
             <div className="h-px bg-border-dim mt-4 lg:mt-5 mb-3 lg:mb-4" />
 
             {/* Tab content */}
-            <div className="min-h-tab-min lg:min-h-[14rem]">
+            <div className="h-tab-min lg:h-[20rem] overflow-y-auto">
               {activeTab === "BASIC" && <BasicTab />}
               {activeTab === "SKILLS" && <SkillsTab />}
               {activeTab === "LINKS" && <LinksTab />}
@@ -186,31 +186,27 @@ export function ProfilePanel() {
             vectorEffect="non-scaling-stroke"
           />
         </svg>
-      </div>
 
-      {/* Fixed tab bar island */}
-      <div className="fixed bottom-4 left-0 right-0 z-50 flex justify-center">
-        <div className="w-full max-w-panel-max lg:max-w-xl px-4 lg:px-6">
-          <div className="w-full max-w-panel-inner lg:max-w-none border-2 border-muted-light bg-bg-button flex items-center p-2 gap-2">
-            {TABS.map((tab, i) => (
-              <button
-                key={tab}
-                type="button"
-                onClick={() => setActiveTab(tab)}
-                className={`flex-1 h-tab-h lg:h-[2.5rem] text-sm lg:text-lg font-squada tracking-wider transition-colors ${i > 0 ? "-ml-2" : ""} ${
-                  activeTab === tab
-                    ? "bg-accent text-text-on-accent z-10"
-                    : "bg-bg-dark text-muted-light hover:text-text-sub"
-                }`}
-                style={{
-                  clipPath:
-                    "polygon(12px 0, 100% 0, calc(100% - 12px) 100%, 0 100%)",
-                }}
-              >
-                {tab}
-              </button>
-            ))}
-          </div>
+        {/* Tab bar island */}
+        <div className="w-full border-2 border-muted-light bg-bg-button flex items-center p-2 gap-2 mt-2">
+          {TABS.map((tab, i) => (
+            <button
+              key={tab}
+              type="button"
+              onClick={() => setActiveTab(tab)}
+              className={`flex-1 h-tab-h lg:h-[2.5rem] text-sm lg:text-lg font-squada tracking-wider transition-colors ${i > 0 ? "-ml-2" : ""} ${
+                activeTab === tab
+                  ? "bg-accent text-text-on-accent z-10"
+                  : "bg-bg-dark text-muted-light hover:text-text-sub"
+              }`}
+              style={{
+                clipPath:
+                  "polygon(12px 0, 100% 0, calc(100% - 12px) 100%, 0 100%)",
+              }}
+            >
+              {tab}
+            </button>
+          ))}
         </div>
       </div>
     </div>

--- a/src/components/profile-panel.tsx
+++ b/src/components/profile-panel.tsx
@@ -188,7 +188,7 @@ export function ProfilePanel() {
         </svg>
 
         {/* Tab bar island */}
-        <div className="w-full border-2 border-muted-light bg-bg-button flex items-center p-2 gap-2 mt-2">
+        <div className="w-full border-2 border-muted-light bg-bg-button flex items-center p-2 gap-2 mt-3">
           {TABS.map((tab, i) => (
             <button
               key={tab}

--- a/src/components/profile-panel.tsx
+++ b/src/components/profile-panel.tsx
@@ -186,28 +186,28 @@ export function ProfilePanel() {
             vectorEffect="non-scaling-stroke"
           />
         </svg>
+      </div>
 
-        {/* Tab bar island */}
-        <div className="w-full border-2 border-muted-light bg-bg-button flex items-center p-2 gap-2 mt-3">
-          {TABS.map((tab, i) => (
-            <button
-              key={tab}
-              type="button"
-              onClick={() => setActiveTab(tab)}
-              className={`flex-1 h-tab-h lg:h-[2.5rem] text-sm lg:text-lg font-squada tracking-wider transition-colors ${i > 0 ? "-ml-2" : ""} ${
-                activeTab === tab
-                  ? "bg-accent text-text-on-accent z-10"
-                  : "bg-bg-dark text-muted-light hover:text-text-sub"
-              }`}
-              style={{
-                clipPath:
-                  "polygon(12px 0, 100% 0, calc(100% - 12px) 100%, 0 100%)",
-              }}
-            >
-              {tab}
-            </button>
-          ))}
-        </div>
+      {/* Tab bar island */}
+      <div className="w-full max-w-panel-inner lg:max-w-none border-2 border-muted-light bg-bg-button flex items-center p-2 gap-2 mt-3">
+        {TABS.map((tab, i) => (
+          <button
+            key={tab}
+            type="button"
+            onClick={() => setActiveTab(tab)}
+            className={`flex-1 h-tab-h lg:h-[2.5rem] text-sm lg:text-lg font-squada tracking-wider transition-colors ${i > 0 ? "-ml-2" : ""} ${
+              activeTab === tab
+                ? "bg-accent text-text-on-accent z-10"
+                : "bg-bg-dark text-muted-light hover:text-text-sub"
+            }`}
+            style={{
+              clipPath:
+                "polygon(12px 0, 100% 0, calc(100% - 12px) 100%, 0 100%)",
+            }}
+          >
+            {tab}
+          </button>
+        ))}
       </div>
     </div>
   );

--- a/src/components/profile-panel.tsx
+++ b/src/components/profile-panel.tsx
@@ -189,26 +189,28 @@ export function ProfilePanel() {
       </div>
 
       {/* Fixed tab bar island */}
-      <div className="fixed bottom-4 left-0 right-0 z-50 flex justify-center px-4 lg:px-6">
-        <div className="w-full max-w-panel-max lg:max-w-xl border-2 border-muted-light bg-bg-button flex items-center p-2 gap-2">
-          {TABS.map((tab, i) => (
-            <button
-              key={tab}
-              type="button"
-              onClick={() => setActiveTab(tab)}
-              className={`flex-1 h-tab-h lg:h-[2.5rem] text-sm lg:text-lg font-squada tracking-wider transition-colors ${i > 0 ? "-ml-2" : ""} ${
-                activeTab === tab
-                  ? "bg-accent text-text-on-accent z-10"
-                  : "bg-bg-dark text-muted-light hover:text-text-sub"
-              }`}
-              style={{
-                clipPath:
-                  "polygon(12px 0, 100% 0, calc(100% - 12px) 100%, 0 100%)",
-              }}
-            >
-              {tab}
-            </button>
-          ))}
+      <div className="fixed bottom-4 left-0 right-0 z-50 flex justify-center">
+        <div className="w-full max-w-panel-max lg:max-w-xl px-4 lg:px-6">
+          <div className="w-full max-w-panel-inner lg:max-w-none border-2 border-muted-light bg-bg-button flex items-center p-2 gap-2">
+            {TABS.map((tab, i) => (
+              <button
+                key={tab}
+                type="button"
+                onClick={() => setActiveTab(tab)}
+                className={`flex-1 h-tab-h lg:h-[2.5rem] text-sm lg:text-lg font-squada tracking-wider transition-colors ${i > 0 ? "-ml-2" : ""} ${
+                  activeTab === tab
+                    ? "bg-accent text-text-on-accent z-10"
+                    : "bg-bg-dark text-muted-light hover:text-text-sub"
+                }`}
+                style={{
+                  clipPath:
+                    "polygon(12px 0, 100% 0, calc(100% - 12px) 100%, 0 100%)",
+                }}
+              >
+                {tab}
+              </button>
+            ))}
+          </div>
         </div>
       </div>
     </div>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -7,7 +7,7 @@ export const Route = createFileRoute("/")({
 
 function HomePage() {
   return (
-    <div className="flex flex-col items-start py-4 pb-20 min-h-screen">
+    <div className="flex flex-col items-start py-4 min-h-screen">
       <ProfilePanel />
     </div>
   );

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -7,7 +7,7 @@ export const Route = createFileRoute("/")({
 
 function HomePage() {
   return (
-    <div className="flex flex-col items-start py-4 min-h-screen">
+    <div className="flex flex-col items-start py-4 pb-20 min-h-screen">
       <ProfilePanel />
     </div>
   );

--- a/src/styles.css
+++ b/src/styles.css
@@ -65,7 +65,7 @@
   --spacing-back-w: 8.5rem; /* 136px */
   --spacing-panel-max: 26rem; /* 416px */
   --spacing-panel-inner: 24rem; /* 384px */
-  --spacing-tab-min: 12rem; /* 192px */
+  --spacing-tab-min: 16rem; /* 256px */
 }
 
 :root {


### PR DESCRIPTION
## Summary
- BASIC / SKILLS / LINKS タブバーをメインパネルから分離し、独立した「島」コンテナとして配置
- `position: fixed` で画面下部に固定表示
- ボタンの平行四辺形 clip-path デザインは維持

## Test plan
- [x] BASIC / SKILLS / LINKS タブの切り替えが正常に動作することを確認
- [x] モバイル表示でもタブバーが正しく配置されることを確認
- [x] Biome lint / typecheck が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)