### PR TITLE
refactor: unify border colors to border-specific tokens

### DIFF
--- a/src/components/angled-button.tsx
+++ b/src/components/angled-button.tsx
@@ -12,7 +12,7 @@ export function AngledButton({ to, label }: AngledButtonProps) {
       className="relative inline-flex items-center h-btn-h lg:h-14 w-btn-w lg:w-56 group"
     >
       {/* Base dark rectangle */}
-      <div className="absolute inset-0 bg-bg-button border-2 border-bg-header" />
+      <div className="absolute inset-0 bg-bg-button border-2 border-border-dark" />
 
       {/* Label text */}
       <span className="relative z-10 text-xl text-text-main font-squada pl-3 leading-none">

--- a/src/components/profile-panel.tsx
+++ b/src/components/profile-panel.tsx
@@ -69,7 +69,7 @@ function SkillsTab() {
             {s.name}
           </span>
           {s.good && (
-            <span className="text-2xs lg:text-sm tracking-wider text-accent/70 font-squada border border-accent/30 rounded-full px-1.5 lg:px-2.5 py-0.5 lg:py-1 leading-none">
+            <span className="text-2xs lg:text-sm tracking-wider text-accent/70 font-squada border border-border-accent rounded-full px-1.5 lg:px-2.5 py-0.5 lg:py-1 leading-none">
               ★ good
             </span>
           )}
@@ -189,7 +189,7 @@ export function ProfilePanel() {
       </div>
 
       {/* Tab bar island */}
-      <div className="w-full max-w-panel-inner lg:max-w-none border-2 border-muted-light bg-bg-button flex items-center p-2 gap-2 mt-3">
+      <div className="w-full max-w-panel-inner lg:max-w-none border-2 border-border-strong bg-bg-button flex items-center p-2 gap-2 mt-3">
         {TABS.map((tab, i) => (
           <button
             key={tab}

--- a/src/components/profile-panel.tsx
+++ b/src/components/profile-panel.tsx
@@ -181,7 +181,7 @@ export function ProfilePanel() {
         >
           <path
             d="M0 0 L370 0 L370 40 L362 48 L362 452 L370 460 L370 500 L0 500 Z"
-            stroke="var(--color-muted)"
+            stroke="var(--color-border-strong)"
             strokeWidth="2"
             vectorEffect="non-scaling-stroke"
           />

--- a/src/styles.css
+++ b/src/styles.css
@@ -11,10 +11,13 @@
   --color-bg-panel: #2a2a2a;
   --color-bg-button: #333333;
 
-  /* Border */
+  /* Border (dark → light) */
+  --color-border-dark: #111111;
+  --color-border-dim: #333333;
   --color-border: #444444;
   --color-border-light: #555555;
-  --color-border-dim: #333333;
+  --color-border-strong: #999999;
+  --color-border-accent: oklch(63.7% 0.237 29.23 / 0.3);
 
   /* Muted (disabled / locked) */
   --color-muted: #666666;

--- a/src/styles.css
+++ b/src/styles.css
@@ -16,7 +16,7 @@
   --color-border-dim: #333333;
   --color-border: #444444;
   --color-border-light: #555555;
-  --color-border-strong: #999999;
+  --color-border-strong: #666666;
   --color-border-accent: oklch(63.7% 0.237 29.23 / 0.3);
 
   /* Muted (disabled / locked) */


### PR DESCRIPTION
## Summary
- border カラーに `bg-header`, `muted-light`, `accent/30`, `muted` など非 border トークンを使っていた箇所を、border 専用トークンに統一
- `--color-border-dark`, `--color-border-strong`, `--color-border-accent` を新規追加
- プロフィールパネルの SVG 疑似 border とタブバーの border 色を `border-strong` (#666666) に統一

## Test plan
- [x] `nr build` 成功
- [x] `nr lint` 成功
- [x] ブラウザで BASIC / SKILLS / LINKS 各タブの表示を目視確認
- [x] パネル枠線とタブバー枠線の色が一致することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)