### PR TITLE
[codex] add codex agent config

### DIFF
--- a/.agents/skills/design-critique/SKILL.md
+++ b/.agents/skills/design-critique/SKILL.md
@@ -1,0 +1,122 @@
+---
+argument-hint: <Figma URL, screenshot, or description>
+description: Get structured design feedback on usability, hierarchy, and consistency. Trigger with "review this design", "critique this mockup", "what do you think of this screen?", or when sharing a Figma link or screenshot for feedback at any stage from exploration to final polish.
+metadata:
+    github-path: design/skills/design-critique
+    github-ref: refs/heads/main
+    github-repo: https://github.com/anthropics/knowledge-work-plugins
+    github-tree-sha: 7c246346e4e343637cc9a805df5ed87d34f74913
+name: design-critique
+---
+# /design-critique
+
+> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+
+Get structured design feedback across multiple dimensions.
+
+## Usage
+
+```
+/design-critique $ARGUMENTS
+```
+
+Review the design: @$1
+
+If a Figma URL is provided, pull the design from Figma. If a file is referenced, read it. Otherwise, ask the user to describe or share their design.
+
+## What I Need From You
+
+- **The design**: Figma URL, screenshot, or detailed description
+- **Context**: What is this? Who is it for? What stage (exploration, refinement, final)?
+- **Focus** (optional): "Focus on mobile" or "Focus on the onboarding flow"
+
+## Critique Framework
+
+### 1. First Impression (2 seconds)
+- What draws the eye first? Is that correct?
+- What's the emotional reaction?
+- Is the purpose immediately clear?
+
+### 2. Usability
+- Can the user accomplish their goal?
+- Is the navigation intuitive?
+- Are interactive elements obvious?
+- Are there unnecessary steps?
+
+### 3. Visual Hierarchy
+- Is there a clear reading order?
+- Are the right elements emphasized?
+- Is whitespace used effectively?
+- Is typography creating the right hierarchy?
+
+### 4. Consistency
+- Does it follow the design system?
+- Are spacing, colors, and typography consistent?
+- Do similar elements behave similarly?
+
+### 5. Accessibility
+- Color contrast ratios
+- Touch target sizes
+- Text readability
+- Alternative text for images
+
+## How to Give Feedback
+
+- **Be specific**: "The CTA competes with the navigation" not "the layout is confusing"
+- **Explain why**: Connect feedback to design principles or user needs
+- **Suggest alternatives**: Don't just identify problems, propose solutions
+- **Acknowledge what works**: Good feedback includes positive observations
+- **Match the stage**: Early exploration gets different feedback than final polish
+
+## Output
+
+```markdown
+## Design Critique: [Design Name]
+
+### Overall Impression
+[1-2 sentence first reaction — what works, what's the biggest opportunity]
+
+### Usability
+| Finding | Severity | Recommendation |
+|---------|----------|----------------|
+| [Issue] | 🔴 Critical / 🟡 Moderate / 🟢 Minor | [Fix] |
+
+### Visual Hierarchy
+- **What draws the eye first**: [Element] — [Is this correct?]
+- **Reading flow**: [How does the eye move through the layout?]
+- **Emphasis**: [Are the right things emphasized?]
+
+### Consistency
+| Element | Issue | Recommendation |
+|---------|-------|----------------|
+| [Typography/spacing/color] | [Inconsistency] | [Fix] |
+
+### Accessibility
+- **Color contrast**: [Pass/fail for key text]
+- **Touch targets**: [Adequate size?]
+- **Text readability**: [Font size, line height]
+
+### What Works Well
+- [Positive observation 1]
+- [Positive observation 2]
+
+### Priority Recommendations
+1. **[Most impactful change]** — [Why and how]
+2. **[Second priority]** — [Why and how]
+3. **[Third priority]** — [Why and how]
+```
+
+## If Connectors Available
+
+If **~~design tool** is connected:
+- Pull the design directly from Figma and inspect components, tokens, and layers
+- Compare against the existing design system for consistency
+
+If **~~user feedback** is connected:
+- Cross-reference design decisions with recent user feedback and support tickets
+
+## Tips
+
+1. **Share the context** — "This is a checkout flow for a B2B SaaS" helps me give relevant feedback.
+2. **Specify your stage** — Early exploration gets different feedback than final polish.
+3. **Ask me to focus** — "Just look at the navigation" gives you more depth on one area.

--- a/.agents/skills/design-handoff/SKILL.md
+++ b/.agents/skills/design-handoff/SKILL.md
@@ -1,0 +1,135 @@
+---
+argument-hint: <Figma URL or design description>
+description: Generate developer handoff specs from a design. Use when a design is ready for engineering and needs a spec sheet covering layout, design tokens, component props, interaction states, responsive breakpoints, edge cases, and animation details.
+metadata:
+    github-path: design/skills/design-handoff
+    github-ref: refs/heads/main
+    github-repo: https://github.com/anthropics/knowledge-work-plugins
+    github-tree-sha: bd7c03d03990314220955f6fee82c9db055a7332
+name: design-handoff
+---
+# /design-handoff
+
+> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+
+Generate comprehensive developer handoff documentation from a design.
+
+## Usage
+
+```
+/design-handoff $ARGUMENTS
+```
+
+Generate handoff specs for: @$1
+
+If a Figma URL is provided, pull the design from Figma. Otherwise, work from the provided description or screenshot.
+
+## What to Include
+
+### Visual Specifications
+- Exact measurements (padding, margins, widths)
+- Design token references (colors, typography, spacing)
+- Responsive breakpoints and behavior
+- Component variants and states
+
+### Interaction Specifications
+- Click/tap behavior
+- Hover states
+- Transitions and animations (duration, easing)
+- Gesture support (swipe, pinch, long-press)
+
+### Content Specifications
+- Character limits
+- Truncation behavior
+- Empty states
+- Loading states
+- Error states
+
+### Edge Cases
+- Minimum/maximum content
+- International text (longer strings)
+- Slow connections
+- Missing data
+
+### Accessibility
+- Focus order
+- ARIA labels and roles
+- Keyboard interactions
+- Screen reader announcements
+
+## Principles
+
+1. **Don't assume** — If it's not specified, the developer will guess. Specify everything.
+2. **Use tokens, not values** — Reference `spacing-md` not `16px`.
+3. **Show all states** — Default, hover, active, disabled, loading, error, empty.
+4. **Describe the why** — "This collapses on mobile because users primarily use one-handed" helps developers make good judgment calls.
+
+## Output
+
+```markdown
+## Handoff Spec: [Feature/Screen Name]
+
+### Overview
+[What this screen/feature does, user context]
+
+### Layout
+[Grid system, breakpoints, responsive behavior]
+
+### Design Tokens Used
+| Token | Value | Usage |
+|-------|-------|-------|
+| `color-primary` | #[hex] | CTA buttons, links |
+| `spacing-md` | [X]px | Between sections |
+| `font-heading-lg` | [size/weight/family] | Page title |
+
+### Components
+| Component | Variant | Props | Notes |
+|-----------|---------|-------|-------|
+| [Component] | [Variant] | [Props] | [Special behavior] |
+
+### States and Interactions
+| Element | State | Behavior |
+|---------|-------|----------|
+| [CTA Button] | Hover | [Background darken 10%] |
+| [CTA Button] | Loading | [Spinner, disabled] |
+| [Form] | Error | [Red border, error message below] |
+
+### Responsive Behavior
+| Breakpoint | Changes |
+|------------|---------|
+| Desktop (>1024px) | [Default layout] |
+| Tablet (768-1024px) | [What changes] |
+| Mobile (<768px) | [What changes] |
+
+### Edge Cases
+- **Empty state**: [What to show when no data]
+- **Long text**: [Truncation rules]
+- **Loading**: [Skeleton or spinner]
+- **Error**: [Error state appearance]
+
+### Animation / Motion
+| Element | Trigger | Animation | Duration | Easing |
+|---------|---------|-----------|----------|--------|
+| [Element] | [Trigger] | [Description] | [ms] | [easing] |
+
+### Accessibility Notes
+- [Focus order]
+- [ARIA labels needed]
+- [Keyboard interactions]
+```
+
+## If Connectors Available
+
+If **~~design tool** is connected:
+- Pull exact measurements, tokens, and component specs from Figma
+- Export assets and generate a complete spec sheet
+
+If **~~project tracker** is connected:
+- Link the handoff to the implementation ticket
+- Create sub-tasks for each section of the spec
+
+## Tips
+
+1. **Share the Figma link** — I can pull exact measurements, tokens, and component info.
+2. **Mention edge cases** — "What happens with 100 items?" helps me spec boundary conditions.
+3. **Specify the tech stack** — "We use React + Tailwind" helps me give relevant implementation notes.

--- a/.agents/skills/design-system/SKILL.md
+++ b/.agents/skills/design-system/SKILL.md
@@ -1,0 +1,194 @@
+---
+argument-hint: '[audit | document | extend] <component or system>'
+description: Audit, document, or extend your design system. Use when checking for naming inconsistencies or hardcoded values across components, writing documentation for a component's variants, states, and accessibility notes, or designing a new pattern that fits the existing system.
+metadata:
+    github-path: design/skills/design-system
+    github-ref: refs/heads/main
+    github-repo: https://github.com/anthropics/knowledge-work-plugins
+    github-tree-sha: 083f8c4110389572da1e46b769740beb31935609
+name: design-system
+---
+# /design-system
+
+> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+
+Manage your design system — audit for consistency, document components, or design new patterns.
+
+## Usage
+
+```
+/design-system audit                    # Full system audit
+/design-system document [component]     # Document a component
+/design-system extend [pattern]         # Design a new component or pattern
+```
+
+## Components of a Design System
+
+### Design Tokens
+Atomic values that define the visual language:
+- Colors (brand, semantic, neutral)
+- Typography (scale, weights, line heights)
+- Spacing (scale, component padding)
+- Borders (radius, width)
+- Shadows (elevation levels)
+- Motion (durations, easings)
+
+### Components
+Reusable UI elements with defined:
+- Variants (primary, secondary, ghost)
+- States (default, hover, active, disabled, loading, error)
+- Sizes (sm, md, lg)
+- Behavior (interactions, animations)
+- Accessibility (ARIA, keyboard)
+
+### Patterns
+Common UI solutions combining components:
+- Forms (input groups, validation, submission)
+- Navigation (sidebar, tabs, breadcrumbs)
+- Data display (tables, cards, lists)
+- Feedback (toasts, modals, inline messages)
+
+## Principles
+
+1. **Consistency over creativity** — The system exists so teams don't reinvent the wheel
+2. **Flexibility within constraints** — Components should be composable, not rigid
+3. **Document everything** — If it's not documented, it doesn't exist
+4. **Version and migrate** — Breaking changes need migration paths
+
+## Output — Audit
+
+```markdown
+## Design System Audit
+
+### Summary
+**Components reviewed:** [X] | **Issues found:** [X] | **Score:** [X/100]
+
+### Naming Consistency
+| Issue | Components | Recommendation |
+|-------|------------|----------------|
+| [Inconsistent naming] | [List] | [Standard to adopt] |
+
+### Token Coverage
+| Category | Defined | Hardcoded Values Found |
+|----------|---------|----------------------|
+| Colors | [X] | [X] instances of hardcoded hex |
+| Spacing | [X] | [X] instances of arbitrary values |
+| Typography | [X] | [X] instances of custom fonts/sizes |
+
+### Component Completeness
+| Component | States | Variants | Docs | Score |
+|-----------|--------|----------|------|-------|
+| Button | ✅ | ✅ | ⚠️ | 8/10 |
+| Input | ✅ | ⚠️ | ❌ | 5/10 |
+
+### Priority Actions
+1. [Most impactful improvement]
+2. [Second priority]
+3. [Third priority]
+```
+
+## Output — Document
+
+```markdown
+## Component: [Name]
+
+### Description
+[What this component is and when to use it]
+
+### Variants
+| Variant | Use When |
+|---------|----------|
+| [Primary] | [Main actions] |
+| [Secondary] | [Supporting actions] |
+
+### Props / Properties
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| [prop] | [type] | [default] | [description] |
+
+### States
+| State | Visual | Behavior |
+|-------|--------|----------|
+| Default | [description] | — |
+| Hover | [description] | [interaction] |
+| Active | [description] | [interaction] |
+| Disabled | [description] | Non-interactive |
+| Loading | [description] | [animation] |
+
+### Accessibility
+- **Role**: [ARIA role]
+- **Keyboard**: [Tab, Enter, Escape behavior]
+- **Screen reader**: [Announced as...]
+
+### Do's and Don'ts
+| ✅ Do | ❌ Don't |
+|------|---------|
+| [Best practice] | [Anti-pattern] |
+
+### Code Example
+[Framework-appropriate code snippet]
+```
+
+## Output — Extend
+
+```markdown
+## New Component: [Name]
+
+### Problem
+[What user need or gap this component addresses]
+
+### Existing Patterns
+| Related Component | Similarity | Why It's Not Enough |
+|-------------------|-----------|---------------------|
+| [Component] | [What's shared] | [What's missing] |
+
+### Proposed Design
+
+#### API / Props
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| [prop] | [type] | [default] | [description] |
+
+#### Variants
+| Variant | Use When | Visual |
+|---------|----------|--------|
+| [Variant] | [Scenario] | [Description] |
+
+#### States
+| State | Behavior | Notes |
+|-------|----------|-------|
+| Default | [Description] | — |
+| Hover | [Description] | [Interaction] |
+| Disabled | [Description] | Non-interactive |
+| Loading | [Description] | [Animation] |
+
+#### Tokens Used
+- Colors: [Which tokens]
+- Spacing: [Which tokens]
+- Typography: [Which tokens]
+
+### Accessibility
+- **Role**: [ARIA role]
+- **Keyboard**: [Expected interactions]
+- **Screen reader**: [Announced as...]
+
+### Open Questions
+- [Decision that needs design review]
+- [Edge case to resolve]
+```
+
+## If Connectors Available
+
+If **~~design tool** is connected:
+- Audit components directly in Figma — check naming, variants, and token usage
+- Pull component properties and layer structure for documentation
+
+If **~~knowledge base** is connected:
+- Search for existing component documentation and usage guidelines
+- Publish updated documentation to your wiki
+
+## Tips
+
+1. **Start with an audit** — Know where you are before deciding where to go.
+2. **Document as you build** — It's easier to document a component while designing it.
+3. **Prioritize coverage over perfection** — 80% of components documented beats 100% of 10 components.

--- a/.agents/skills/figma-mcp/SKILL.md
+++ b/.agents/skills/figma-mcp/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: figma-mcp
+description: Figma デザインからコードを生成する際に使用するスキル。Figma MCP サーバーを活用して、デザインの取得・コード生成・コンポーネントマッピングを行う。
+---
+
+# Figma MCP スキル
+
+Figma デザインからコードを生成する際に使用するスキル。Figma MCP サーバーを活用して、デザインの取得・コード生成・コンポーネントマッピングを行う。
+
+## トリガー条件
+
+ユーザーが以下のいずれかを要求した場合にこのスキルを使用する:
+- Figma の URL やノード ID からコードを生成したい
+- Figma デザインをもとにコンポーネントを実装したい
+- Figma のデザインを確認・スクリーンショットを取得したい
+- Figma のノードとコードベースのコンポーネントをマッピングしたい
+
+## ワークフロー
+
+### 1. Figma URL の解析
+
+ユーザーから Figma URL を受け取ったら、以下を抽出する:
+- `fileKey`: URL の `/design/:fileKey/` 部分
+- `nodeId`: URL の `?node-id=:int1-:int2` 部分 (`-` を `:` に変換)
+- ブランチ URL の場合: `/branch/:branchKey/` の `branchKey` を `fileKey` として使用
+
+### 2. デザインコンテキストの取得
+
+`mcp__figma__get_design_context` を使ってデザイン情報とコード生成用のコンテキストを取得する。これが最も優先されるツール。
+
+### 3. コード生成
+
+取得したデザインコンテキストをもとに、プロジェクトの技術スタックに合わせてコードを生成する:
+- **フレームワーク**: React (関数コンポーネント + TypeScript)
+- **スタイリング**: Tailwind CSS v4 のユーティリティクラス
+- **UIコンポーネント**: shadcn/ui を積極活用
+- **コンポーネント配置**: `src/components/` 配下
+
+### 4. アセットのダウンロード
+
+`get_design_context` が返すアセット URL から必要な画像等をダウンロードし、`public/` ディレクトリに配置する。
+
+## 利用可能な Figma MCP ツール
+
+| ツール | 用途 |
+|---|---|
+| `mcp__figma__get_design_context` | デザインからコード生成用コンテキストを取得 (最優先) |
+| `mcp__figma__get_screenshot` | ノードのスクリーンショットを取得 |
+| `mcp__figma__get_metadata` | ノードの構造・メタデータを XML で取得 |
+| `mcp__figma__get_variable_defs` | デザイン変数 (色・サイズ等) の定義を取得 |
+| `mcp__figma__get_code_connect_map` | ノードとコードコンポーネントのマッピングを取得 |
+| `mcp__figma__add_code_connect_map` | ノードとコードコンポーネントのマッピングを追加 |
+| `mcp__figma__get_code_connect_suggestions` | Code Connect マッピングの提案を取得 |
+| `mcp__figma__generate_diagram` | FigJam でダイアグラムを生成 (Mermaid.js) |
+
+## 注意事項
+
+- `get_design_context` を `get_metadata` より優先して使用する
+- `clientFrameworks` には `react` を指定する
+- `clientLanguages` には `typescript,html,css` を指定する
+- 生成されたコードは Biome で lint/format を通すこと (`nr lint`, `nr format`)
+- shadcn/ui に該当するコンポーネントがある場合は、自前実装せず shadcn/ui を使う

--- a/.agents/skills/geometric-clip-path/SKILL.md
+++ b/.agents/skills/geometric-clip-path/SKILL.md
@@ -1,0 +1,242 @@
+---
+name: geometric-clip-path
+description: 切り欠き（ノッチ）、コーナーカット、平行四辺形などの幾何学的な形状を CSS clip-path polygon() で設計・実装するためのスキル。
+---
+
+# 幾何学的クリップパス・ノッチデザインスキル
+
+切り欠き（ノッチ）、コーナーカット、平行四辺形などの幾何学的な形状を CSS `clip-path: polygon()` で設計・実装するためのスキル。
+
+## トリガー条件
+
+ユーザーが以下のいずれかを要求した場合にこのスキルを使用する:
+
+- 要素にノッチ、切り欠き、コーナーカットを追加したい
+- 平行四辺形、台形、六角形バッジなどの幾何学的形状を作りたい
+- `clip-path` の設計・デバッグをしたい
+- SVG ボーダーと clip-path を組み合わせたパネルデザインを作りたい
+
+## 基本パターン集
+
+### コーナーカット（右下）
+
+```css
+/* CUT = カットサイズ (px) */
+clip-path: polygon(
+  0 0, 100% 0,
+  100% calc(100% - CUT),
+  calc(100% - CUT) 100%,
+  0 100%
+);
+```
+
+### コーナーカット（右上）
+
+```css
+clip-path: polygon(
+  0 0,
+  calc(100% - CUT) 0,
+  100% CUT,
+  100% 100%,
+  0 100%
+);
+```
+
+### コーナーカット（複数コーナー）
+
+```css
+/* 右上 + 右下 */
+clip-path: polygon(
+  0 0,
+  calc(100% - CUT) 0,
+  100% CUT,
+  100% calc(100% - CUT),
+  calc(100% - CUT) 100%,
+  0 100%
+);
+```
+
+### 平行四辺形
+
+```css
+/* 左右の辺が同じ傾きで平行。OFFSET = height / 傾き */
+clip-path: polygon(
+  OFFSET 0,
+  100% 0,
+  calc(100% - OFFSET) 100%,
+  0 100%
+);
+```
+
+### 台形（下辺が広い）
+
+```css
+clip-path: polygon(
+  INSET 0,
+  calc(100% - INSET) 0,
+  100% 100%,
+  0 100%
+);
+```
+
+### 六角形バッジ
+
+```css
+clip-path: polygon(
+  INSET 0,
+  calc(100% - INSET) 0,
+  100% 50%,
+  calc(100% - INSET) 100%,
+  INSET 100%,
+  0 50%
+);
+```
+
+### 矢印（右向き）
+
+```css
+clip-path: polygon(
+  0 0, 70% 0,
+  100% 50%,
+  70% 100%, 0 100%
+);
+```
+
+### サイドノッチ付きパネル
+
+```css
+/* 右辺に上下ノッチ（凹み）を持つパネル */
+clip-path: polygon(
+  0 0,
+  100% 0,
+  100% TOP_NOTCH_START,
+  calc(100% - NOTCH_DEPTH) TOP_NOTCH_END,
+  calc(100% - NOTCH_DEPTH) BOTTOM_NOTCH_START,
+  100% BOTTOM_NOTCH_END,
+  100% 100%,
+  0 100%
+);
+```
+
+## ボーダーの実装方法
+
+### 問題: `border` + `clip-path` の組み合わせ
+
+CSS の `border` は `clip-path` で切られるため、カット部分のボーダーが途切れる。
+
+### 解決策 1: レイヤー重ね（推奨・CSS のみ）
+
+外側にボーダー色の背景、内側に本体の背景を重ねる。
+
+```tsx
+<div className="relative" style={{ clipPath: "polygon(...)" }}>
+  {/* ボーダーレイヤー（背景色 = ボーダー色） */}
+  <div className="absolute inset-0 bg-[BORDER_COLOR]" />
+  {/* 背景レイヤー（B px 内側、カット値を調整） */}
+  <div
+    className="absolute inset-[Bpx] bg-[BG_COLOR]"
+    style={{
+      clipPath: "polygon(...)", /* 内側用に調整（後述） */
+    }}
+  />
+  {/* コンテンツ */}
+  <div className="relative z-10">...</div>
+</div>
+```
+
+#### 斜め辺のボーダー幅を均一にする
+
+`inset` で内側レイヤーを縮めるだけでは、斜め辺のボーダーが水平・垂直辺より太くなる。斜め辺に垂直な方向の距離は、水平・垂直の inset 値より小さくなるため。
+
+均一にするには、内側 clip-path のカット値を斜め辺の角度から計算して調整する必要がある:
+
+```
+斜め辺の角度 θ = atan2(CUT_Y, CUT_X)
+
+水平方向の内側オフセット = B / sin(θ)
+垂直方向の内側オフセット = B / cos(θ)
+
+ただし 45度カット（CUT_X == CUT_Y）の場合:
+  内側カット値 ≈ CUT - B * (√2 - 1) ≈ CUT - B * 0.414
+```
+
+**実用的な近似:** 45度カットでボーダー幅 1px の場合、内側カット値を外側より 1px 小さくすれば視覚的にはほぼ問題ない。厳密な均一性が必要な場合のみ上記の計算を行う。
+
+### 解決策 2: SVG ボーダーオーバーレイ（可変高さパネル向け）
+
+パネル全体に SVG を `absolute inset-0` で重ねてボーダーを描画する。SVG の `stroke` は辺の角度に関係なく均一な太さで描画されるため、斜め辺の太さ調整が不要。
+
+```tsx
+<div className="relative w-full">
+  <div className="relative" style={{ clipPath: "..." }}>
+    {/* コンテンツ */}
+  </div>
+  <svg
+    className="absolute inset-0 w-full h-full pointer-events-none"
+    viewBox="0 0 WIDTH HEIGHT"
+    preserveAspectRatio="none"
+    fill="none"
+  >
+    <path d="M0 0 L..." stroke="..." strokeWidth="2" vectorEffect="non-scaling-stroke" />
+  </svg>
+</div>
+```
+
+**注意:** `preserveAspectRatio="none"` は viewBox を引き伸ばすため、斜め辺の角度がアスペクト比で変わる。`vectorEffect="non-scaling-stroke"` でストローク幅は維持される。
+
+### 使い分け
+
+| 状況 | 推奨手法 |
+|---|---|
+| 固定サイズ or 高さが大きく変わらない要素 | レイヤー重ね |
+| 斜め辺のボーダー幅の均一性が重要 | SVG オーバーレイ |
+| 可変高さのパネル全体のボーダー | SVG オーバーレイ |
+| ボーダー不要（背景のみ） | clip-path 単体で OK |
+
+## 設計のコツ
+
+### 傾きの統一
+
+プロジェクト全体で斜め辺の傾きを統一すると一貫性が出る。基準を決めて揃えること。
+
+例: **y = 2x**（高さに対して水平オフセットが半分）を基準にする場合:
+
+```
+高さ 24px → オフセット 12px
+高さ 32px → オフセット 16px
+高さ 42px → オフセット 21px
+```
+
+### 左右非対称な形状のパディング調整
+
+コーナーカットや斜めカットで左右非対称な形状を作ると、中のコンテンツが視覚的に偏って見える場合がある。clip-path で切り取られた領域にコンテンツが被らないよう、カット側のパディングを追加する必要がある。
+
+```tsx
+{/* 右下カット: 右側・下側のパディングをカット分だけ増やす */}
+<div style={{ clipPath: "polygon(0 0, 100% 0, 100% calc(100% - 32px), calc(100% - 32px) 100%, 0 100%)" }}>
+  <div className="pl-4 pr-12 pt-4 pb-10">  {/* 右と下を多めに */}
+    ...
+  </div>
+</div>
+
+{/* 平行四辺形: 左右のパディングをオフセット分だけ増やす */}
+<div style={{ clipPath: "polygon(16px 0, 100% 0, calc(100% - 16px) 100%, 0 100%)" }}>
+  <div className="px-8">  {/* 左右を多めに */}
+    ...
+  </div>
+</div>
+```
+
+**原則:** カットされる三角形の底辺の半分程度を、その方向のパディングに加算すると自然に見える。
+
+### px と % の使い分け
+
+- **固定サイズ要素**: `px` を使う（角度が安定）
+- **可変幅要素**: 水平方向に `calc(100% - Npx)` でカットサイズを `px` 固定
+- **完全レスポンシブ**: `%` のみ（ただし角度がアスペクト比に依存）
+
+### clip-path のデバッグ
+
+1. 背景色を目立つ色に一時的に変更して形状を確認
+2. ブラウザ DevTools で `clip-path` を直接編集して微調整
+3. 複雑な形状は紙に座標を描いてから実装する

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,6 @@
+[mcp_servers.shadcn]
+args = [
+    "shadcn@latest",
+    "mcp",
+]
+command = "bunx"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,59 @@
+# ojii3.dev - ポートフォリオサイト
+
+## プロジェクト概要
+
+OJII3 の個人ポートフォリオサイト。
+
+## 技術スタック
+
+- **フレームワーク**: React + Vite
+- **ルーティング**: TanStack Router (ファイルベースルーティング)
+- **スタイリング**: Tailwind CSS v4
+- **UIコンポーネント**: shadcn/ui
+- **ランタイム/パッケージマネージャ**: Bun
+- **デプロイ**: Cloudflare Workers
+- **リンター/フォーマッター**: Biome
+
+## ページ構成 (予定)
+
+- **トップページ (`/`)**: ヒーローセクション、簡単な自己紹介、主要な作品のハイライト
+- **プロジェクト一覧 (`/projects`)**: プロジェクト一覧 (GitHub 連携等)
+
+## 開発コマンド
+
+```sh
+nr dev          # 開発サーバー起動
+nr build        # プロダクションビルド
+nr preview      # ビルド結果のプレビュー
+nr lint         # Biome による lint
+nr format       # Biome による format
+nr deploy       # Cloudflare Workers へデプロイ
+bun test        # テスト実行 (Bun 予約コマンド)
+```
+
+## Git 戦略
+
+- 一つの機能追加ごとに test を作成する
+- 一つの機能追加ごとに commit する
+- 一つの機能変更ごとに commit する
+- commit はシンプルな conventional commit
+- 一つの機能・領域に関する変更が完了するごとに PR を作成
+
+## テスト戦略
+
+- `nr test`, `nr lint` を使用してチェックを行なう
+- デザインの指定がある場合、Codex in Chrome を用いて corner や border の形状が一致するか確認する
+
+## その他ルール
+
+- コンポーネントを shadcn/ui で作成する
+- Tailwind では arbitrary value を可能なかぎり避けトークンを使用する
+- Tailwind のトークンは可能な限り上書きせず、追加もしくは、shadcn/ui で吸収する
+- `rm -rf` の代わりに `gomi -rf` を使う
+
+## AGENTS.md メンテナンスルール
+
+- **plan 完了後**: 設計変更・技術選定の結果を AGENTS.md に反映する
+- **機能追加・削除後**: ページ構成、ディレクトリ構成、技術スタック、開発コマンドを更新する
+- **依存関係変更後**: 技術スタックや開発コマンドに差分があれば更新する
+- AGENTS.md は常にプロジェクトの現状と一致させること


### PR DESCRIPTION
## Summary

- Add `AGENTS.md` with Codex-oriented project instructions based on the existing project guidance.
- Add repository-local Codex skills under `.agents/skills` for design critique, handoff, design system work, Figma MCP usage, and geometric clip-path implementation.
- Add `.codex/config.toml` to configure the shadcn MCP server for Codex.

## Impact

This gives Codex the same project-specific operating context and reusable skill definitions needed for this portfolio site, while keeping Claude-specific files untouched.

## Validation

- `nr lint` passed.
- pre-commit hook passed: Biome check and typecheck.
- `nix develop --command sh -c 'nr build'` passed.
- GitHub Actions `upload` check passed.

## Note

Running `nr build` from Codex's non-devShell environment picked up `/Applications/Codex.app/Contents/Resources/node`, which cannot load Rollup's native optional dependency because of macOS library validation. Running inside the project's Nix devShell uses the flake-provided Node and builds successfully.
