### PR TITLE
[codex] Organize style tokens

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,13 @@ bun test        # テスト実行 (Bun 予約コマンド)
 - `nr test`, `nr lint` を使用してチェックを行なう
 - デザインの指定がある場合、Codex in Chrome を用いて corner や border の形状が一致するか確認する
 
+## スタイルトークン方針
+
+- Tailwind v4 の `@theme` トークンは `src/styles.css` に集約する
+- 色トークンは `canvas`, `surface-*`, `line-*`, `content-*`, `brand-*` の意味ベースで命名する
+- コンポーネント固有の固定寸法は spacing / aspect トークンとして定義し、arbitrary value は可能なかぎり避ける
+- `clip-path` などの幾何形状は `@layer utilities` の `clip-*` utility に集約し、コンポーネント内の inline style に埋め込まない
+
 ## その他ルール
 
 - コンポーネントを shadcn/ui で作成する

--- a/src/components/angled-button.tsx
+++ b/src/components/angled-button.tsx
@@ -9,26 +9,21 @@ export function AngledButton({ to, label }: AngledButtonProps) {
   return (
     <Link
       to={to}
-      className="relative inline-flex items-center h-btn-h lg:h-14 w-btn-w lg:w-56 group"
+      className="relative inline-flex items-center h-action-h lg:h-14 w-action-w lg:w-56 group"
     >
       {/* Base dark rectangle */}
-      <div className="absolute inset-0 bg-bg-button border-2 border-border-dark" />
+      <div className="absolute inset-0 bg-surface-control border-2 border-line-deep" />
 
       {/* Label text */}
-      <span className="relative z-10 text-xl text-text-main font-squada pl-3 leading-none">
+      <span className="relative z-10 text-xl text-content-primary font-squada pl-3 leading-none">
         {label}
       </span>
 
       {/* Orange angled section */}
-      <div
-        className="absolute right-0 top-0 h-full w-[67px] lg:w-[80px] bg-accent"
-        style={{
-          clipPath: "polygon(30% 0, 100% 0, 100% 100%, 0 100%)",
-        }}
-      />
+      <div className="absolute right-0 top-0 h-full w-angled-accent-w lg:w-angled-accent-w-lg bg-brand clip-angled-action" />
 
       {/* Double chevron >> */}
-      <div className="absolute right-[4px] top-1/2 -translate-y-1/2 z-10 flex items-center gap-0">
+      <div className="absolute right-angled-chevron-offset top-1/2 -translate-y-1/2 z-10 flex items-center gap-0">
         <svg
           width="18"
           height="28"
@@ -39,7 +34,7 @@ export function AngledButton({ to, label }: AngledButtonProps) {
         >
           <path
             d="M0 0L14 14L0 28"
-            stroke="var(--color-bg-main)"
+            stroke="var(--color-canvas)"
             strokeWidth="4"
           />
         </svg>
@@ -52,7 +47,7 @@ export function AngledButton({ to, label }: AngledButtonProps) {
         >
           <path
             d="M0 0L14 14L0 28"
-            stroke="var(--color-bg-main)"
+            stroke="var(--color-canvas)"
             strokeWidth="4"
           />
         </svg>

--- a/src/components/clipped-card.tsx
+++ b/src/components/clipped-card.tsx
@@ -8,38 +8,31 @@ export function ClippedCard({ variant, title, subtitle }: ClippedCardProps) {
   const isPreview = variant === "preview";
 
   return (
-    <div
-      className="relative w-full aspect-[177/236] overflow-hidden"
-      style={{
-        clipPath: "polygon(0 0, 85% 0, 100% 12%, 100% 100%, 0 100%)",
-      }}
-    >
+    <div className="relative w-full aspect-project-card overflow-hidden clip-project-card">
       {/* Background gradient */}
       <div
         className={`absolute inset-0 ${
           isPreview
-            ? "bg-gradient-to-b from-accent to-accent-dark"
-            : "bg-gradient-to-b from-muted-light to-muted"
+            ? "bg-gradient-to-b from-brand to-brand-pressed"
+            : "bg-gradient-to-b from-content-muted to-content-disabled"
         }`}
       />
 
       {/* Border effect */}
       <div
-        className="absolute inset-[3px] bg-gradient-to-b"
-        style={{
-          clipPath: "polygon(0 0, 85% 0, 100% 13%, 100% 100%, 0 100%)",
-          background: isPreview
-            ? "linear-gradient(to bottom, var(--color-accent), var(--color-accent-darker))"
-            : "linear-gradient(to bottom, var(--color-muted-mid), var(--color-border-light))",
-        }}
+        className={`absolute inset-shape-border bg-gradient-to-b clip-project-card-inner ${
+          isPreview
+            ? "from-brand to-brand-deep"
+            : "from-content-disabled to-line-emphasis"
+        }`}
       />
 
       {/* Content */}
       <div className="relative z-10 flex flex-col justify-between h-full p-4 lg:p-5">
-        <p className="text-xl text-text-on-accent font-squada leading-none">
+        <p className="text-xl text-content-inverse font-squada leading-none">
           {isPreview ? "PREVIEW" : "NO DATA"}
         </p>
-        <div className="text-text-sub text-base lg:text-xl font-squada leading-tight">
+        <div className="text-content-secondary text-base lg:text-xl font-squada leading-tight">
           {isPreview && title ? <p>{title}</p> : <p>{subtitle ?? "LOCKED"}</p>}
         </div>
       </div>

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -6,19 +6,14 @@ type HeaderProps = {
 
 export function Header({ title }: HeaderProps) {
   return (
-    <header className="relative bg-bg-header h-16 lg:h-20 w-full flex items-center overflow-hidden">
+    <header className="relative bg-surface-header h-16 lg:h-20 w-full flex items-center overflow-hidden">
       {/* Back link - angular arrow shape */}
       <Link
         to="/"
         className="relative h-full w-back-w lg:w-40 flex items-center justify-center group"
       >
         {/* Arrow background */}
-        <div
-          className="absolute inset-0 bg-border group-hover:bg-border-light transition-colors"
-          style={{
-            clipPath: "polygon(0 0, 70% 0, 100% 50%, 70% 100%, 0 100%)",
-          }}
-        />
+        <div className="absolute inset-0 bg-line-default group-hover:bg-line-emphasis transition-colors clip-back-link" />
         {/* Arrow icon */}
         <svg
           width="32"
@@ -30,7 +25,7 @@ export function Header({ title }: HeaderProps) {
         >
           <path
             d="M20 8L12 16L20 24"
-            stroke="white"
+            stroke="var(--color-content-primary)"
             strokeWidth="3"
             strokeLinecap="round"
             strokeLinejoin="round"
@@ -39,7 +34,7 @@ export function Header({ title }: HeaderProps) {
       </Link>
 
       {/* Title - aligned right */}
-      <h1 className="absolute right-4 text-3xl lg:text-4xl text-text-main font-squada leading-none">
+      <h1 className="absolute right-4 text-3xl lg:text-4xl text-content-primary font-squada leading-none">
         {title}
       </h1>
     </header>

--- a/src/components/link-card.tsx
+++ b/src/components/link-card.tsx
@@ -7,9 +7,8 @@ type LinkCardProps = {
 };
 
 export function LinkCard({ label, href, external = false }: LinkCardProps) {
-  const clipStyle = {
-    clipPath: "polygon(0 0, 92% 0, 100% 100%, 0 100%)",
-  };
+  const className =
+    "relative flex items-center h-link-h lg:h-12 w-full bg-surface-sunken border border-line-subtle hover:border-brand transition-colors group clip-link-card";
 
   if (external) {
     return (
@@ -17,10 +16,9 @@ export function LinkCard({ label, href, external = false }: LinkCardProps) {
         href={href}
         target="_blank"
         rel="noopener noreferrer"
-        className="relative flex items-center h-link-h lg:h-12 w-full bg-bg-dark border border-border-dim hover:border-accent transition-colors group"
-        style={clipStyle}
+        className={className}
       >
-        <span className="text-base lg:text-xl text-text-sub font-squada pl-3 tracking-wide group-hover:text-accent transition-colors">
+        <span className="text-base lg:text-xl text-content-secondary font-squada pl-3 tracking-wide group-hover:text-brand transition-colors">
           {label}
         </span>
         <svg
@@ -35,7 +33,7 @@ export function LinkCard({ label, href, external = false }: LinkCardProps) {
             d="M3 11L11 3M11 3H5M11 3V9"
             stroke="currentColor"
             strokeWidth="1.5"
-            className="text-muted group-hover:text-accent transition-colors"
+            className="text-content-disabled group-hover:text-brand transition-colors"
           />
         </svg>
       </a>
@@ -43,12 +41,8 @@ export function LinkCard({ label, href, external = false }: LinkCardProps) {
   }
 
   return (
-    <Link
-      to={href}
-      className="relative flex items-center h-link-h lg:h-12 w-full bg-bg-dark border border-border-dim hover:border-accent transition-colors group"
-      style={clipStyle}
-    >
-      <span className="text-base lg:text-xl text-text-sub font-squada pl-3 tracking-wide group-hover:text-accent transition-colors">
+    <Link to={href} className={className}>
+      <span className="text-base lg:text-xl text-content-secondary font-squada pl-3 tracking-wide group-hover:text-brand transition-colors">
         {label}
       </span>
       <svg
@@ -63,7 +57,7 @@ export function LinkCard({ label, href, external = false }: LinkCardProps) {
           d="M2 7H12M8 3L12 7L8 11"
           stroke="currentColor"
           strokeWidth="1.5"
-          className="text-muted group-hover:text-accent transition-colors"
+          className="text-content-disabled group-hover:text-brand transition-colors"
         />
       </svg>
     </Link>

--- a/src/components/profile-panel.tsx
+++ b/src/components/profile-panel.tsx
@@ -39,7 +39,7 @@ function BasicTab() {
             <Tooltip>
               <TooltipTrigger asChild>
                 <span className="inline-flex items-center gap-1 cursor-help">
-                  <Info className="size-3 lg:size-4 text-muted-light" />
+                  <Info className="size-3 lg:size-4 text-content-muted" />
                   TUAT
                 </span>
               </TooltipTrigger>
@@ -61,15 +61,15 @@ function SkillsTab() {
       {SKILLS.map((s) => (
         <div
           key={s.name}
-          className="flex items-center justify-between py-1.5 lg:py-2 border-b border-border-dim"
+          className="flex items-center justify-between py-1.5 lg:py-2 border-b border-line-subtle"
         >
           <span
-            className={`text-sm lg:text-lg tracking-wider ${s.good ? "text-accent" : "text-muted-light"}`}
+            className={`text-sm lg:text-lg tracking-wider ${s.good ? "text-brand" : "text-content-muted"}`}
           >
             {s.name}
           </span>
           {s.good && (
-            <span className="text-2xs lg:text-sm tracking-wider text-accent/70 font-squada border border-border-accent rounded-full px-1.5 lg:px-2.5 py-0.5 lg:py-1 leading-none">
+            <span className="text-2xs lg:text-sm tracking-wider text-brand/70 font-squada border border-line-brand rounded-full px-1.5 lg:px-2.5 py-0.5 lg:py-1 leading-none">
               ★ good
             </span>
           )}
@@ -94,45 +94,27 @@ export function ProfilePanel() {
   return (
     <div className="flex flex-col items-start overflow-hidden p-4 lg:p-6 w-full max-w-panel-max lg:max-w-xl mx-auto">
       {/* Section label */}
-      <p className="text-xs lg:text-sm tracking-[0.2em] text-muted-light uppercase mb-2 lg:mb-3 pl-1">
+      <p className="text-xs lg:text-sm tracking-label text-content-muted uppercase mb-2 lg:mb-3 pl-1">
         profile
       </p>
 
       <div className="relative w-full max-w-panel-inner lg:max-w-none">
         {/* Background panel */}
-        <div
-          className="relative bg-bg-panel w-full"
-          style={{
-            clipPath:
-              "polygon(0 0, 100% 0, 100% 40px, calc(100% - 8px) 48px, calc(100% - 8px) calc(100% - 48px), 100% calc(100% - 40px), 100% 100%, 0 100%)",
-          }}
-        >
+        <div className="relative bg-surface-raised w-full clip-profile-frame">
           <div className="p-4 lg:p-6 pr-6 pb-4">
             {/* Name & Avatar area */}
-            <div
-              className="relative h-avatar-area lg:h-[7.5rem] w-full"
-              style={{
-                clipPath:
-                  "polygon(0 0, 100% 0, 100% calc(100% - 32px), calc(100% - 32px) 100%, 0 100%)",
-              }}
-            >
+            <div className="relative h-avatar-area lg:h-avatar-area-lg w-full clip-profile-hero">
               {/* Border layer */}
-              <div className="absolute inset-0 bg-border-light" />
+              <div className="absolute inset-0 bg-line-emphasis" />
               {/* Background layer */}
-              <div
-                className="absolute inset-[1px] bg-bg-dark"
-                style={{
-                  clipPath:
-                    "polygon(0 0, 100% 0, 100% calc(100% - 31px), calc(100% - 31px) 100%, 0 100%)",
-                }}
-              />
+              <div className="absolute inset-px bg-surface-sunken clip-profile-hero-inner" />
               {/* Content */}
               <div className="relative z-10 flex items-center justify-between h-full">
                 <div className="pl-5">
-                  <p className="text-2xl lg:text-4xl text-white font-squada leading-none">
+                  <p className="text-2xl lg:text-4xl text-content-primary font-squada leading-none">
                     OKAZU
                   </p>
-                  <p className="text-sm lg:text-lg text-muted-light tracking-wider mt-1">
+                  <p className="text-sm lg:text-lg text-content-muted tracking-wider mt-1">
                     CS Student
                   </p>
                 </div>
@@ -140,7 +122,7 @@ export function ProfilePanel() {
                 <img
                   src="/images/avatar.png"
                   alt="Avatar"
-                  className="w-avatar lg:w-[5rem] h-avatar lg:h-[5rem] rounded-full object-cover mr-14 shrink-0"
+                  className="w-avatar lg:w-avatar-lg h-avatar lg:h-avatar-lg rounded-full object-cover mr-14 shrink-0"
                 />
               </div>
             </div>
@@ -148,22 +130,16 @@ export function ProfilePanel() {
             {/* Level badge + Tech tags */}
             <div className="flex items-center gap-2 mt-3 flex-wrap">
               {/* Level badge */}
-              <span
-                className="inline-flex items-center justify-center h-badge-h lg:h-[1.875rem] px-3 lg:px-4 bg-accent text-xs-plus lg:text-sm font-squada text-text-on-accent tracking-wider"
-                style={{
-                  clipPath:
-                    "polygon(4px 0, calc(100% - 4px) 0, 100% 50%, calc(100% - 4px) 100%, 4px 100%, 0 50%)",
-                }}
-              >
+              <span className="inline-flex items-center justify-center h-badge-h lg:h-badge-h-lg px-3 lg:px-4 bg-brand text-xs-plus lg:text-sm font-squada text-content-inverse tracking-wider clip-badge">
                 B4
               </span>
             </div>
 
             {/* Separator */}
-            <div className="h-px bg-border-dim mt-4 lg:mt-5 mb-3 lg:mb-4" />
+            <div className="h-px bg-line-subtle mt-4 lg:mt-5 mb-3 lg:mb-4" />
 
             {/* Tab content */}
-            <div className="h-tab-min lg:h-[20rem] overflow-y-auto">
+            <div className="h-tab-min lg:h-tab-min-lg overflow-y-auto">
               {activeTab === "BASIC" && <BasicTab />}
               {activeTab === "SKILLS" && <SkillsTab />}
               {activeTab === "LINKS" && <LinksTab />}
@@ -181,7 +157,7 @@ export function ProfilePanel() {
         >
           <path
             d="M0 0 L370 0 L370 40 L362 48 L362 452 L370 460 L370 500 L0 500 Z"
-            stroke="var(--color-border-strong)"
+            stroke="var(--color-line-strong)"
             strokeWidth="2"
             vectorEffect="non-scaling-stroke"
           />
@@ -189,21 +165,17 @@ export function ProfilePanel() {
       </div>
 
       {/* Tab bar island */}
-      <div className="w-full max-w-panel-inner lg:max-w-none border-2 border-border-strong bg-bg-button flex items-center p-2 gap-2 mt-3">
+      <div className="w-full max-w-panel-inner lg:max-w-none border-2 border-line-strong bg-surface-control flex items-center p-2 gap-2 mt-3">
         {TABS.map((tab, i) => (
           <button
             key={tab}
             type="button"
             onClick={() => setActiveTab(tab)}
-            className={`flex-1 h-tab-h lg:h-[2.5rem] text-sm lg:text-lg font-squada tracking-wider transition-colors ${i > 0 ? "-ml-2" : ""} ${
+            className={`flex-1 h-tab-h lg:h-tab-h-lg text-sm lg:text-lg font-squada tracking-wider transition-colors clip-tab ${i > 0 ? "-ml-tab-overlap" : ""} ${
               activeTab === tab
-                ? "bg-accent text-text-on-accent z-10"
-                : "bg-bg-dark text-muted-light hover:text-text-sub"
+                ? "bg-brand text-content-inverse z-10"
+                : "bg-surface-sunken text-content-muted hover:text-content-secondary"
             }`}
-            style={{
-              clipPath:
-                "polygon(12px 0, 100% 0, calc(100% - 12px) 100%, 0 100%)",
-            }}
           >
             {tab}
           </button>

--- a/src/components/stat-row.tsx
+++ b/src/components/stat-row.tsx
@@ -8,13 +8,13 @@ type StatRowProps = {
 
 export function StatRow({ label, value, accent = false }: StatRowProps) {
   return (
-    <div className="flex items-baseline justify-between py-1.5 lg:py-2 border-b border-border-dim">
-      <span className="text-sm lg:text-lg tracking-widest text-muted-light uppercase">
+    <div className="flex items-baseline justify-between py-1.5 lg:py-2 border-b border-line-subtle">
+      <span className="text-sm lg:text-lg tracking-widest text-content-muted uppercase">
         {label}
       </span>
       <span
         className={`text-base lg:text-xl font-squada tracking-wide ${
-          accent ? "text-accent" : "text-text-sub"
+          accent ? "text-brand" : "text-content-secondary"
         }`}
       >
         {value}

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -40,13 +40,13 @@ function TooltipContent({
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         className={cn(
-          "bg-bg-panel border border-border-light text-text-sub animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) px-3 py-1.5 text-xs text-balance",
+          "bg-surface-raised border border-line-emphasis text-content-secondary animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit tooltip-content-origin px-3 py-1.5 text-xs text-balance",
           className,
         )}
         {...props}
       >
         {children}
-        <TooltipPrimitive.Arrow className="bg-bg-panel fill-bg-panel z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45" />
+        <TooltipPrimitive.Arrow className="bg-surface-raised fill-surface-raised z-50 size-2.5 tooltip-arrow-offset rotate-45" />
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>
   );

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -6,7 +6,7 @@ export const Route = createRootRoute({
 
 function RootLayout() {
   return (
-    <div className="min-h-screen bg-bg-main text-text-main font-squada">
+    <div className="min-h-screen bg-canvas text-content-primary font-squada">
       <Outlet />
     </div>
   );

--- a/src/styles.css
+++ b/src/styles.css
@@ -4,35 +4,32 @@
 @theme {
   --font-squada: "Squada One", sans-serif;
 
-  /* Background (dark → light) */
-  --color-bg-header: #111111;
-  --color-bg-dark: #1a1a1a;
-  --color-bg-main: #222222;
-  --color-bg-panel: #2a2a2a;
-  --color-bg-button: #333333;
+  /* Surfaces */
+  --color-canvas: #222222;
+  --color-surface-header: #111111;
+  --color-surface-sunken: #1a1a1a;
+  --color-surface-raised: #2a2a2a;
+  --color-surface-control: #333333;
 
-  /* Border (dark → light) */
-  --color-border-dark: #111111;
-  --color-border-dim: #333333;
-  --color-border: #444444;
-  --color-border-light: #555555;
-  --color-border-strong: #666666;
-  --color-border-accent: oklch(63.7% 0.237 29.23 / 0.3);
+  /* Lines */
+  --color-line-deep: #111111;
+  --color-line-subtle: #333333;
+  --color-line-default: #444444;
+  --color-line-emphasis: #555555;
+  --color-line-strong: #666666;
+  --color-line-brand: oklch(63.7% 0.237 29.23 / 0.3);
 
-  /* Muted (disabled / locked) */
-  --color-muted: #666666;
-  --color-muted-mid: #888888;
-  --color-muted-light: #999999;
+  /* Content */
+  --color-content-primary: #ffffff;
+  --color-content-secondary: #cccccc;
+  --color-content-muted: #999999;
+  --color-content-disabled: #666666;
+  --color-content-inverse: #000000;
 
-  /* Accent */
-  --color-accent: #ff3300;
-  --color-accent-dark: #cc2200;
-  --color-accent-darker: #991100;
-
-  /* Text */
-  --color-text-main: #ffffff;
-  --color-text-sub: #cccccc;
-  --color-text-on-accent: #000000;
+  /* Brand */
+  --color-brand: #ff3300;
+  --color-brand-pressed: #cc2200;
+  --color-brand-deep: #991100;
 
   /* Font sizes (rem-based tokens) */
   --font-size-2xs: 0.8125rem; /* 13px */
@@ -57,18 +54,34 @@
   --font-size-3xl--line-height: 1;
   --font-size-4xl--line-height: 1;
 
+  /* Letter spacing */
+  --tracking-label: 0.2em;
+
   /* Spacing tokens (rem-based) */
-  --spacing-btn-h: 2.75rem; /* 44px */
-  --spacing-btn-w: 11.5rem; /* 184px */
+  --spacing-action-h: 2.75rem; /* 44px */
+  --spacing-action-w: 11.5rem; /* 184px */
   --spacing-link-h: 2.375rem; /* 38px */
   --spacing-tab-h: 2.125rem; /* 34px */
+  --spacing-tab-h-lg: 2.5rem; /* 40px */
+  --spacing-tab-overlap: 0.5rem; /* 8px */
   --spacing-badge-h: 1.625rem; /* 26px */
+  --spacing-badge-h-lg: 1.875rem; /* 30px */
   --spacing-avatar-area: 6.5rem; /* 104px */
+  --spacing-avatar-area-lg: 7.5rem; /* 120px */
   --spacing-avatar: 4.25rem; /* 68px */
+  --spacing-avatar-lg: 5rem; /* 80px */
   --spacing-back-w: 8.5rem; /* 136px */
   --spacing-panel-max: 26rem; /* 416px */
   --spacing-panel-inner: 24rem; /* 384px */
   --spacing-tab-min: 16rem; /* 256px */
+  --spacing-tab-min-lg: 20rem; /* 320px */
+  --spacing-angled-accent-w: 4.1875rem; /* 67px */
+  --spacing-angled-accent-w-lg: 5rem; /* 80px */
+  --spacing-angled-chevron-offset: 0.25rem; /* 4px */
+  --spacing-shape-border: 0.1875rem; /* 3px */
+
+  /* Aspect ratios */
+  --aspect-project-card: 177 / 236;
 }
 
 :root {
@@ -77,7 +90,85 @@
 
 body {
   margin: 0;
-  background-color: var(--color-bg-main);
-  color: var(--color-text-main);
+  background-color: var(--color-canvas);
+  color: var(--color-content-primary);
   font-family: var(--font-squada);
+}
+
+@layer utilities {
+  .clip-angled-action {
+    clip-path: polygon(30% 0, 100% 0, 100% 100%, 0 100%);
+  }
+
+  .clip-back-link {
+    clip-path: polygon(0 0, 70% 0, 100% 50%, 70% 100%, 0 100%);
+  }
+
+  .clip-badge {
+    clip-path: polygon(
+      4px 0,
+      calc(100% - 4px) 0,
+      100% 50%,
+      calc(100% - 4px) 100%,
+      4px 100%,
+      0 50%
+    );
+  }
+
+  .clip-link-card {
+    clip-path: polygon(0 0, 92% 0, 100% 100%, 0 100%);
+  }
+
+  .clip-profile-frame {
+    clip-path: polygon(
+      0 0,
+      100% 0,
+      100% 40px,
+      calc(100% - 8px) 48px,
+      calc(100% - 8px) calc(100% - 48px),
+      100% calc(100% - 40px),
+      100% 100%,
+      0 100%
+    );
+  }
+
+  .clip-profile-hero {
+    clip-path: polygon(
+      0 0,
+      100% 0,
+      100% calc(100% - 32px),
+      calc(100% - 32px) 100%,
+      0 100%
+    );
+  }
+
+  .clip-profile-hero-inner {
+    clip-path: polygon(
+      0 0,
+      100% 0,
+      100% calc(100% - 31px),
+      calc(100% - 31px) 100%,
+      0 100%
+    );
+  }
+
+  .clip-project-card {
+    clip-path: polygon(0 0, 85% 0, 100% 12%, 100% 100%, 0 100%);
+  }
+
+  .clip-project-card-inner {
+    clip-path: polygon(0 0, 85% 0, 100% 13%, 100% 100%, 0 100%);
+  }
+
+  .clip-tab {
+    clip-path: polygon(12px 0, 100% 0, calc(100% - 12px) 100%, 0 100%);
+  }
+
+  .tooltip-content-origin {
+    transform-origin: var(--radix-tooltip-content-transform-origin);
+  }
+
+  .tooltip-arrow-offset {
+    translate: 0 calc(-50% - 2px);
+  }
 }


### PR DESCRIPTION
## Summary

- Reorganized Tailwind v4 style tokens into semantic color groups: canvas, surface, line, content, and brand.
- Moved component geometry such as clip-path shapes and fixed sizing into theme tokens and utility classes.
- Updated component usages and documented the token policy in AGENTS.md.

## Validation

- nr lint
- nr build
- pre-commit: biome-check, typecheck
