### PR TITLE
fix: デプロイで Node 22 を使用

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,6 +24,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
@@ -92,6 +97,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
## 概要
- Wrangler 4.88.0 が Node.js 22 以上を要求するため、Deploy workflow の upload / publish job で Node 22 を明示
- publish の `bun wrangler versions list` が runner 標準 Node 20 を拾って失敗する問題を修正

## 確認
- nr lint
- nr build

## 失敗原因
- main の Deploy run 25424135176 で publish / Get version ID が `Wrangler requires at least Node.js v22.0.0. You are using v20.20.2.` により失敗