### PR TITLE
ci: GitHub Actions を最新タグに更新

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,15 +22,15 @@ jobs:
       version_tag: ${{ steps.version.outputs.tag }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: 22
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@v2.2.0
         with:
           bun-version-file: ".bun-version"
 
@@ -60,7 +60,7 @@ jobs:
         run: bun run build
 
       - name: Upload version
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v3.15.0
         id: upload
         with:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -96,15 +96,15 @@ jobs:
       url: ${{ steps.deploy.outputs.deployment-url }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: 22
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@v2.2.0
         with:
           bun-version-file: ".bun-version"
 
@@ -128,7 +128,7 @@ jobs:
           echo "version_id=${version_id}" >> "$GITHUB_OUTPUT"
 
       - name: Deploy to production
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v3.15.0
         id: deploy
         with:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## 概要
- Deploy workflow の GitHub Actions を最新リリースタグに更新
  - actions/checkout@v6.0.2
  - actions/setup-node@v6.4.0
  - oven-sh/setup-bun@v2.2.0
  - cloudflare/wrangler-action@v3.15.0

## 確認
- nr lint
- nr build

## 参照
- https://github.com/actions/checkout/releases/tag/v6.0.2
- https://github.com/actions/setup-node/releases/tag/v6.4.0
- https://github.com/oven-sh/setup-bun/releases/tag/v2.2.0
- https://github.com/cloudflare/wrangler-action/releases/tag/v3.15.0