### PR TITLE
fix: use dynamic viewport height

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,7 @@ bun test        # テスト実行 (Bun 予約コマンド)
 - Tailwind v4 の `@theme` トークンは `src/styles.css` に集約する
 - 色トークンは `canvas`, `surface-*`, `line-*`, `content-*`, `brand-*` の意味ベースで命名する
 - コンポーネント固有の固定寸法は spacing / aspect トークンとして定義し、arbitrary value は可能なかぎり避ける
+- ページ全体やモーダルの画面高計算は、モバイルブラウザの動的ツールバーを考慮して `vh` ではなく `dvh` を使う
 - `clip-path` などの幾何形状は `@layer utilities` の `clip-*` utility に集約し、コンポーネント内の inline style に埋め込まない
 - トップページの Canvas 予約領域など、複数トークンを組み合わせるレイアウトは `@layer utilities` の semantic utility に集約する
 

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -7,7 +7,7 @@ export const Route = createRootRoute({
 
 function RootLayout() {
   return (
-    <div className="min-h-screen bg-canvas text-content-primary font-squada">
+    <div className="min-h-dvh bg-canvas text-content-primary font-squada">
       <Outlet />
       <TanStackRouterDevtools />
     </div>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -7,7 +7,7 @@ export const Route = createFileRoute("/")({
 
 function HomePage() {
   return (
-    <main className="min-h-screen px-4 py-4 lg:px-8 lg:py-6">
+    <main className="min-h-dvh px-4 py-4 lg:px-8 lg:py-6">
       <div className="home-profile-shell mx-auto">
         <div className="home-model-stage" aria-hidden="true" />
         <ProfilePanel className="lg:mx-0 lg:justify-self-end" />

--- a/src/routes/projects.tsx
+++ b/src/routes/projects.tsx
@@ -167,7 +167,7 @@ function ProjectDetailPanel({ project }: { project: Project }) {
 
 function ProjectsPage() {
   return (
-    <main className="flex min-h-screen flex-col gap-4">
+    <main className="flex min-h-dvh flex-col gap-4">
       <Header title="WORKS" />
 
       <div className="mx-auto grid w-full max-w-panel-max box-border grid-cols-2 gap-4 px-4 pb-6 lg:max-w-projects-grid-max lg:grid-cols-4 lg:gap-5 lg:px-0 lg:pt-2">

--- a/src/styles.css
+++ b/src/styles.css
@@ -77,7 +77,7 @@
   --spacing-projects-grid-max: 48rem; /* 768px */
   --spacing-project-detail-max: 44rem; /* 704px */
   --spacing-project-detail-media: 11.5rem; /* 184px */
-  --spacing-project-detail-scroll: calc(100vh - 7rem);
+  --spacing-project-detail-scroll: calc(100dvh - 7rem);
   --spacing-panel-inner: 24rem; /* 384px */
   --spacing-home-content-max: 72rem; /* 1152px */
   --spacing-home-profile-max: 36rem; /* 576px */
@@ -113,7 +113,7 @@ body {
     align-items: center;
     width: 100%;
     max-width: var(--spacing-home-content-max);
-    min-height: calc(100vh - 2rem);
+    min-height: calc(100dvh - 2rem);
   }
 
   .home-model-stage {
@@ -241,7 +241,7 @@ body {
         minmax(var(--spacing-home-stage-min), 1fr)
         minmax(0, var(--spacing-home-profile-max));
       column-gap: var(--spacing-home-gap);
-      min-height: calc(100vh - 3rem);
+      min-height: calc(100dvh - 3rem);
     }
 
     .home-model-stage {


### PR DESCRIPTION
## Summary
- Replace page-level min-height utilities with dynamic viewport height
- Update viewport-based CSS calculations from 100vh to 100dvh
- Document the dvh policy for page and modal height calculations

## Verification
- nr lint
- nr build
- Mobile browser check at 390x844 for / and /projects modal