### PR TITLE
fix: align profile frame border at all viewport sizes

### DIFF
--- a/src/components/profile-panel.tsx
+++ b/src/components/profile-panel.tsx
@@ -123,9 +123,12 @@ export function ProfilePanel({ className }: ProfilePanelProps) {
       </p>
 
       <div className="relative w-full max-w-panel-inner lg:max-w-none">
-        {/* Background panel */}
-        <div className="relative bg-surface-raised w-full clip-profile-frame">
-          <div className="py-8 pl-4 lg:pl-6 pr-6 lg:pr-8 pb-4">
+        {/* Background panel with border */}
+        <div className="relative bg-line-strong w-full clip-profile-frame">
+          {/* Inner background */}
+          <div className="absolute inset-0.5 bg-surface-raised clip-profile-frame-inner" />
+
+          <div className="relative z-10 py-8 pl-4 lg:pl-6 pr-6 lg:pr-8 pb-4">
             {/* Name & Avatar area */}
             <div className="relative h-avatar-area lg:h-avatar-area-lg w-full clip-profile-hero">
               {/* Border layer */}
@@ -155,14 +158,6 @@ export function ProfilePanel({ className }: ProfilePanelProps) {
               </div>
             </div>
 
-            {/* Level badge + Tech tags */}
-            {/* <div className="flex items-center gap-2 mt-3 flex-wrap"> */}
-            {/* Level badge */}
-            {/*   <span className="inline-flex items-center justify-center h-badge-h lg:h-badge-h-lg px-3 lg:px-4 bg-brand text-xs-plus lg:text-sm font-squada text-content-inverse tracking-wider clip-badge"> */}
-            {/*     B4 */}
-            {/*   </span> */}
-            {/* </div> */}
-
             {/* Separator */}
             <div className="h-px bg-line-subtle mt-4 lg:mt-5 mb-3 lg:mb-4" />
 
@@ -178,22 +173,6 @@ export function ProfilePanel({ className }: ProfilePanelProps) {
             </div>
           </div>
         </div>
-
-        {/* SVG border outline */}
-        <svg
-          className="absolute inset-0 w-full h-full pointer-events-none"
-          viewBox="0 0 370 500"
-          preserveAspectRatio="none"
-          fill="none"
-          aria-hidden="true"
-        >
-          <path
-            d="M0 0 L370 0 L370 40 L362 48 L362 452 L370 460 L370 500 L0 500 Z"
-            stroke="var(--color-line-strong)"
-            strokeWidth="2"
-            vectorEffect="non-scaling-stroke"
-          />
-        </svg>
       </div>
 
       {/* Tab bar island */}

--- a/src/styles.css
+++ b/src/styles.css
@@ -166,6 +166,19 @@ body {
     );
   }
 
+  .clip-profile-frame-inner {
+    clip-path: polygon(
+      0 0,
+      100% 0,
+      100% 37px,
+      calc(100% - 8px) 45px,
+      calc(100% - 8px) calc(100% - 45px),
+      100% calc(100% - 37px),
+      100% 100%,
+      0 100%
+    );
+  }
+
   .clip-profile-hero {
     clip-path: polygon(
       0 0,


### PR DESCRIPTION
## Summary
- 旧実装は固定 `viewBox` の SVG に `preserveAspectRatio=\"none\"` を当てており、パネルがリサイズされると SVG が非均一に引き伸ばされて、絶対 px で定義された `clip-profile-frame` のノッチ位置とずれていた（特に PC サイズで顕著）
- SVG をやめ、hero セクションと同じレイヤード div パターンに変更（外側 `bg-line-strong` + clip-profile-frame、内側 `inset-0.5 bg-surface-raised` + 新規 `clip-profile-frame-inner`）
- `clip-profile-frame-inner` は外形に対して垂直方向 2px インセットになるよう、ノッチ位置とチャンファー座標を計算

## Test plan
- [x] PC (1280x800) でプロファイルパネルの右辺ノッチと chamfer がボーダーと整列することを Playwright スクショで確認
- [x] モバイル (390x844) でも同様に整列することを確認
- [x] `nr lint` / `nr build` パス